### PR TITLE
Add default development configurations and improve container tags

### DIFF
--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -9,3 +9,6 @@ RUN apt-get update && \
 
 RUN pip install --src ../src -r requirements/edx/testing.txt && \
     pip install --src ../src -r requirements/edx/development.txt
+
+# Copy default configurations for development
+COPY ./config /config/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
 
   lms:
     build: .
-    image: fun-platform-edxapp
+    image: fun-platform-edxapp:ginkgo.1
     environment:
       SERVICE_VARIANT: lms
       DJANGO_SETTINGS_MODULE: lms.envs.docker_run
@@ -45,7 +45,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile_dev
-    image: fun-platform-edxapp-dev
+    image: fun-platform-edxapp:ginkgo.1-dev
     ports:
       - "8072:8000"
     volumes:
@@ -58,7 +58,7 @@ services:
       - lms
 
   cms:
-    image: fun-platform-edxapp
+    image: fun-platform-edxapp:ginkgo.1
     environment:
       SERVICE_VARIANT: cms
       DJANGO_SETTINGS_MODULE: cms.envs.docker_run
@@ -68,7 +68,7 @@ services:
       - lms
 
   cms-dev:
-    image: fun-platform-edxapp-dev
+    image: fun-platform-edxapp:ginkgo.1-dev
     ports:
       - "8082:8000"
     volumes:


### PR DESCRIPTION
## Container tag schema

We will stick to Open edX release tags, e.g. `ginkgo.1`, for `fun-platform-edxapp` container tags.

A development container tag will be suffixed by `-dev`, e.g. `ginkgo.1-dev`

## Default configurations for development

This PR adds default configurations to containers used for development purpose. This is useful to avoid having to copy all configuration files when its not required (_i.e._ if not overridden).
