### PR TITLE
ci(circle) add build & build-dev jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,262 @@
+# fun-platform
+# Docker containers CI
+version: 2
+
+# List fun-platform jobs that will be integrated and executed in a workflow
+jobs:
+
+  # Build job
+  # Build the Docker container ready for production
+  build:
+
+    # We use the machine executor, i.e. a VM, not a container
+    machine:
+      # Cache docker layers so that we strongly speed up this job execution
+      docker_layer_caching: true
+
+    working_directory: ~/fun
+
+    steps:
+      # Checkout fun-platform sources
+      - checkout
+
+      # Restore the ~/fun/src cached repository. If the cache does not exists for
+      # the current .Revision (commit hash), we fall back to the latest cache
+      # with a label matching 'edx-v1-'
+      - restore_cache:
+          keys:
+            - edx-v1-{{ .Revision }}
+            - edx-v1-
+
+      # Clone Open edX sources
+      - run:
+          name: Clone Open edX platform
+          command: |
+            bin/clone_repositories
+
+      # Production container build, it will be tagged as edxapp:latest
+      - run:
+          name: Build container
+          command: |
+            docker build -t edxapp:latest .
+
+      # Cache Open edX repository (cloned in ~/fun/src) as the checkout is
+      # rather time consuming for this project
+      - save_cache:
+          paths:
+            - ~/fun/src
+          key: edx-v1-{{ .Revision }}
+
+      # Save and compress production container to ~/docker/edxapp.tgz
+      - run:
+          name: Save container
+          command: |
+            mkdir ~/docker
+            docker save edxapp | gzip > ~/docker/edxapp.tgz
+
+      # Cache containers directory to load them in another job
+      - save_cache:
+          paths:
+            - ~/docker
+          key: docker-v1-{{ .Revision }}
+
+  # Build dev job
+  # Build the Docker container ready for development
+  build-dev:
+
+    machine:
+      docker_layer_caching: true
+
+    working_directory: ~/fun
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - edx-v1-{{ .Revision }}
+            - edx-v1-
+
+      # Development container build, it uses the Dockerfile_dev file and will be
+      # tagged as edxapp:dev
+      - run:
+          name: Build container
+          command: |
+            docker build -t edxapp:dev -f Dockerfile_dev .
+
+      # We also save this container
+      - run:
+          name: Save container
+          command: |
+            mkdir ~/docker
+            docker save edxapp | gzip > ~/docker/edxapp-dev.tgz
+
+      # We store the development container in a new cache
+      - save_cache:
+          paths:
+            - ~/docker
+          key: docker-dev-v1-{{ .Revision }}
+
+  # Hub job
+  # Load and tag production/development containers to push them to the Docker hub
+  # public registry
+  hub:
+
+    # We use a VM (not a container), with no docker layer cache as we will not
+    # build containers in this step.
+    machine: true
+
+    steps:
+
+      # Restore containers caches
+      - restore_cache:
+          keys:
+            - docker-v1-{{ .Revision }}
+      - restore_cache:
+          keys:
+            - docker-dev-v1-{{ .Revision }}
+
+      # Load saved containers
+      - run:
+          name: Load cached containers
+          command: |
+            gunzip -c ~/docker/edxapp.tgz | docker load
+            gunzip -c ~/docker/edxapp-dev.tgz | docker load
+
+      # Check that docker images have been loaded
+      - run:
+          name: Check docker image tags
+          command: |
+            docker images edxapp
+
+      # Login to DockerHub with encrypted credentials stored as secret
+      # environment variables (set in CircleCI project settings)
+      - run:
+          name: Login to DockerHub
+          command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+
+      # Tag containers with our DockerHub namespace (fundocker/), and list
+      # images to check that they have been properly tagged
+      - run:
+          name: Tag container
+          command: |
+            docker tag edxapp fundocker/edxapp:ginkgo.1
+            docker images fundocker/edxapp
+
+      # Publish production container to DockerHub
+      - run:
+          name: Publish container
+          command: docker push fundocker/edxapp:ginkgo.1
+
+      # Tag the development container, check tags, and publish it!
+      - run:
+          name: Tag dev container
+          command: |
+            docker tag edxapp:dev fundocker/edxapp:ginkgo.1-dev
+            docker images fundocker/edxapp
+      - run:
+          name: Publish container
+          command: docker push fundocker/edxapp:ginkgo.1-dev
+
+  # Test job
+  # Run the Open edX test suite on build containers.
+  #
+  # FIXME: this job randomly fails for obscure reasons; we need to invest
+  # more time on this issue.
+  test:
+
+    # We use docker layers caching as we might build containers in this job
+    machine:
+      docker_layer_caching: true
+
+    working_directory: ~/fun
+
+    # Allow the execution of parallel sub-jobs (up to 4 for free plans on CircleCI)
+    parallelism: 4
+
+    steps:
+      - checkout
+
+      # Restore only the production container cache...
+      - restore_cache:
+          keys:
+            - docker-v1-{{ .Revision }}
+            - docker-v1-
+
+      # ...and Open edX sources with the test suite to run
+      - restore_cache:
+          keys:
+            - edx-v1-{{ .Revision }}
+            - edx-v1-
+
+      # Load the container
+      - run:
+          name: Load cached container
+          command: |
+            gunzip -c ~/docker/edxapp.tgz | docker load
+
+      # Run the test suite via the Open edX test script: scripts/all-tests.sh
+      # This script requires CI environment variable to run; those are passed to
+      # the container via the `-e` docker run option:
+      #
+      # - CIRCLECI: used by the CI script to select the CI strategy (depending
+      #   on the CI platform)
+      # - CIRCLE_NODE_INDEX/CIRCLE_NODE_TOTAL: used for the parallel execution
+      #   of the test suite
+      # - EDXAPP_TEST_MONGO_HOST: the mongo db host used in tests
+      #
+      # We also need to mount the git repository that is used to integrate
+      # metadata to coverage report (e.g. the current commit hash).
+      - run:
+          name: Run tests
+          command: |
+            docker-compose run --rm \
+              -e CIRCLECI \
+              -e CIRCLE_NODE_INDEX \
+              -e CIRCLE_NODE_TOTAL \
+              -e EDXAPP_TEST_MONGO_HOST='mongodb' \
+              -v "$HOME/fun/src/edx-platform/.git:/app/edx-platform/.git" \
+              lms-dev scripts/all-tests.sh
+
+# CI workflows
+workflows:
+  version: 2
+
+  # We have a single workflow
+  edxapp:
+
+    jobs:
+
+      # The build job has no required jobs, hence this will be our first job
+      - build:
+          # Filtering rule to run this job: none (we accept all tags; this job
+          # will always run).
+          filters:
+            tags:
+              only: /.*/
+
+      # Build the development container only if the production container build
+      # succeeds
+      - build-dev:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+
+      # Once the build-dev job has succeeded, we fork the workflow to run both
+      # the hub and the test jobs "in parallel".
+      - hub:
+          requires:
+            - build-dev
+          filters:
+            tags:
+              only: /.*/
+
+      # FIXME: for now this job can fail
+      - test:
+          requires:
+            - build-dev
+          filters:
+            tags:
+              only: /.*/

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -4,7 +4,7 @@ FROM edxapp:ginkgo.1
 # Removing the package lists after installation is a good practice
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y libsqlite3-dev && \
+    apt-get install -y libsqlite3-dev mongodb && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --src ../src -r requirements/edx/testing.txt && \


### PR DESCRIPTION
NB: The build-dev job depends on the build job to speed up build time by using production container cache.