### PR TITLE
👩‍🏭(paths): revert to same paths as Open edX for installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN apt-get update && \
     python-pip software-properties-common swig && \
     rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app/edx-platform
+WORKDIR /edx/app/edxapp/edx-platform
 
 # Install Python requirements
 # ... adding only targeted requirements files first to benefit from caching
-ADD ./src/edx-platform/requirements/edx /app/edx-platform/requirements/edx
+ADD ./src/edx-platform/requirements/edx /edx/app/edxapp/edx-platform/requirements/edx
 RUN pip install --src ../src -r requirements/edx/pre.txt && \
     pip install --src ../src -r requirements/edx/github.txt && \
     pip install --src ../src -r requirements/edx/base.txt && \
@@ -24,23 +24,23 @@ RUN pip install --src ../src -r requirements/edx/pre.txt && \
 
 # Install Javascript requirements
 # ... adding only the package.json file first to benefit from caching
-ADD ./src/edx-platform/package.json /app/edx-platform/package.json
+ADD ./src/edx-platform/package.json /edx/app/edxapp/edx-platform/package.json
 RUN npm install
 
 # Now add the complete project sources
-ADD ./src/edx-platform /app/edx-platform
+ADD ./src/edx-platform /edx/app/edxapp/edx-platform
 
 # Install the project Python packages
 RUN pip install --src ../src -r requirements/edx/local.txt
 
 # Add configuration files
 RUN mkdir -p /config && \
-    ln -sf /config/lms.env.json /app/lms.env.json && \
-    ln -sf /config/lms.auth.json /app/lms.auth.json && \
-    ln -sf /config/docker_run_lms.py /app/edx-platform/lms/envs/docker_run.py && \
-    ln -sf /config/cms.env.json /app/cms.env.json && \
-    ln -sf /config/cms.auth.json /app/cms.auth.json && \
-    ln -sf /config/docker_run_cms.py /app/edx-platform/cms/envs/docker_run.py
+    ln -sf /config/lms.env.json /edx/app/edxapp/lms.env.json && \
+    ln -sf /config/lms.auth.json /edx/app/edxapp/lms.auth.json && \
+    ln -sf /config/docker_run_lms.py /edx/app/edxapp/edx-platform/lms/envs/docker_run.py && \
+    ln -sf /config/cms.env.json /edx/app/edxapp/cms.env.json && \
+    ln -sf /config/cms.auth.json /edx/app/edxapp/cms.auth.json && \
+    ln -sf /config/docker_run_cms.py /edx/app/edxapp/edx-platform/cms/envs/docker_run.py
 
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.docker_run \

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ clone:  ## clone source repositories
 
 demo-course:  ## import demo course from edX repository
 	@./bin/clone_demo_course
-	$(COMPOSE_RUN) -v $(shell pwd)/src/edx-demo-course:/app/edx-demo-course cms \
-	python manage.py cms import /data/media /app/edx-demo-course
+	$(COMPOSE_RUN) -v $(shell pwd)/src/edx-demo-course:/edx/app/edxapp/edx-demo-course cms \
+	python manage.py cms import /edx/var/edxapp/media /edx/app/edxapp/edx-demo-course
 .PHONY: demo-course
 
 logs:  ## get development logs

--- a/config/cms.env.json
+++ b/config/cms.env.json
@@ -1,7 +1,7 @@
 {
   "SITE_NAME": "localhost:8082",
   "BOOK_URL": "",
-  "LOG_DIR": "/data/logs",
+  "LOG_DIR": "/edx/var/logs/edx",
   "LOGGING_ENV": "sandbox",
   "OAUTH_OIDC_ISSUER": "http://localhost:8072/oauth2",
   "PLATFORM_NAME": "FUN Platform Studio - Open edX",
@@ -14,7 +14,7 @@
   "LMS_BASE": "localhost:8072",
   "CELERY_BROKER_HOSTNAME": "rabbitmq",
   "CELERY_BROKER_TRANSPORT": "amqp",
-  "MEDIA_ROOT": "/data/media",
+  "MEDIA_ROOT": "/edx/var/edxapp/media",
   "STATIC_ROOT_BASE": "",
   "EMAIL_HOST": "smtp",
   "EMAIL_PORT": 9025,

--- a/config/docker_run_cms.py
+++ b/config/docker_run_cms.py
@@ -2,10 +2,10 @@ from .devstack import *
 
 update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
 
-STATIC_ROOT = '/data/static/cms'
+STATIC_ROOT = '/edx/var/edxapp/static/cms'
 STATIC_URL = '/static/'
-MEDIA_ROOT = '/data/media'
-LOG_DIR = '/data/log'
+MEDIA_ROOT = '/edx/var/edxapp/media'
+LOG_DIR = '/edx/var/logs/edx'
 
 FEATURES['ENABLE_DISCUSSION_SERVICE'] = False
 

--- a/config/docker_run_lms.py
+++ b/config/docker_run_lms.py
@@ -2,10 +2,10 @@ from .devstack import *
 
 update_module_store_settings(MODULESTORE, doc_store_settings=DOC_STORE_CONFIG)
 
-STATIC_ROOT = '/data/static/lms'
+STATIC_ROOT = '/edx/var/edxapp/static/lms'
 STATIC_URL = '/static/'
-MEDIA_ROOT = '/data/media'
-LOG_DIR = '/data/log'
+MEDIA_ROOT = '/edx/var/edxapp/media'
+LOG_DIR = '/edx/var/logs/edx'
 
 FEATURES['ENABLE_DISCUSSION_SERVICE'] = False
 

--- a/config/lms.env.json
+++ b/config/lms.env.json
@@ -1,7 +1,7 @@
 {
   "SITE_NAME": "localhost:8072",
   "BOOK_URL": "",
-  "LOG_DIR": "/data/logs",
+  "LOG_DIR": "/edx/var/logs/edx",
   "LOGGING_ENV": "sandbox",
   "OAUTH_OIDC_ISSUER": "http://localhost:8072/oauth2",
   "PLATFORM_NAME": "FUN Platform LMS - Open edX",
@@ -14,7 +14,7 @@
   "CMS_BASE": "localhost:8082",
   "CELERY_BROKER_HOSTNAME": "rabbitmq",
   "CELERY_BROKER_TRANSPORT": "amqp",
-  "MEDIA_ROOT": "/data/media",
+  "MEDIA_ROOT": "/edx/var/edxapp/media",
   "STATIC_ROOT_BASE": "",
   "EMAIL_HOST": "smtp",
   "EMAIL_PORT": 9025,

--- a/dev-volumes.yml
+++ b/dev-volumes.yml
@@ -4,8 +4,8 @@ services:
 
   lms-dev:
     volumes:
-      - ./src/edx-platform:/app/edx-platform
+      - ./src/edx-platform:/edx/app/edxapp/edx-platform
 
   cms-dev:
     volumes:
-      - ./src/edx-platform:/app/edx-platform
+      - ./src/edx-platform:/edx/app/edxapp/edx-platform

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,8 @@ services:
     ports:
       - "8072:8000"
     volumes:
-      - ./data/static/lms:/data/static/lms
-      - ./data/media:/data/media
+      - ./data/static/lms:/edx/var/edxapp/static/lms
+      - ./data/media:/edx/var/edxapp/media
       - ./config:/config
     command: >
       python manage.py lms runserver 0.0.0.0:8000 --settings=docker_run
@@ -72,8 +72,8 @@ services:
     ports:
       - "8082:8000"
     volumes:
-      - ./data/static/cms:/data/static/cms
-      - ./data/media:/data/media
+      - ./data/static/cms:/edx/var/edxapp/static/cms
+      - ./data/media:/edx/var/edxapp/media
       - ./config:/config
 
     command: >


### PR DESCRIPTION
## Purpose
When we implemented the first Dockerfile POC, it seemed easier to copy app files in "/app" and data files in "/data" as is often seen in Dockerfiles.
 
We now realize that we can avoid a lot of tweaks in settings and be friendlier to the Open edX community by sticking to the paths they use in their traditional installation procedure ("/edx/app" and "/edx/var").

## Proposal
Change all paths to revert to Open edX practice.