### PR TITLE
fix(docker) make docker-compose image tags generic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
 
   lms:
     build: .
-    image: edxapp:ginkgo.1
+    image: edxapp:latest
     environment:
       SERVICE_VARIANT: lms
       DJANGO_SETTINGS_MODULE: lms.envs.docker_run
@@ -45,7 +45,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile_dev
-    image: edxapp:ginkgo.1-dev
+    image: edxapp:dev
     ports:
       - "8072:8000"
     volumes:
@@ -58,7 +58,7 @@ services:
       - lms
 
   cms:
-    image: edxapp:ginkgo.1
+    image: edxapp:latest
     environment:
       SERVICE_VARIANT: cms
       DJANGO_SETTINGS_MODULE: cms.envs.docker_run
@@ -68,7 +68,7 @@ services:
       - lms
 
   cms-dev:
-    image: edxapp:ginkgo.1-dev
+    image: edxapp:dev
     ports:
       - "8082:8000"
     volumes:


### PR DESCRIPTION
Avoid hard coded tags such as `ginkgo.1` in docker-compose services image name.

Fix #9