### PR TITLE
ci(circle) restrict hub job to the master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,8 +196,8 @@ workflows:
           requires:
             - build-dev
           filters:
-            tags:
-              only: /.*/
+            branches:
+              only: master
 
       # FIXME: for now this job can fail
       - test:


### PR DESCRIPTION
We do not want to push PR builds to DockerHub, this fix improves the situation by restricting the push job to the master branch.