### PR TITLE
Build and push Docker images with tags matching their git tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ jobs:
 
       # Restore the ~/fun/src cached repository. If the cache does not exists for
       # the current .Revision (commit hash), we fall back to the latest cache
-      # with a label matching 'edx-v1-'
+      # with a label matching 'edx-repository-v1-'
       - restore_cache:
           keys:
-            - edx-v1-{{ .Revision }}
-            - edx-v1-
+            - edx-repository-v1-{{ .Revision }}
+            - edx-repository-v1-
 
       # Clone Open edX sources
       - run:
@@ -36,54 +36,57 @@ jobs:
 
       # Production container build, it will be tagged as edxapp:latest
       - run:
-          name: Build container
+          name: Build production container
           command: |
-            docker build -t edxapp:${CIRCLE_TAG:-latest} .
+            docker build -t edxapp:latest .
+
+      # Build the Docker container ready for development
+      # Development container build uses the Dockerfile_dev file and will be
+      # tagged as edxapp:dev
+      - run:
+          name: Build development container
+          command: |
+            docker build -t edxapp:dev -f Dockerfile_dev .
 
       # Cache Open edX repository (cloned in ~/fun/src) as the checkout is
       # rather time consuming for this project
       - save_cache:
           paths:
             - ~/fun/src/edx-platform/.git
-          key: edx-v1-{{ .Revision }}
+          key: edx-repository-v1-{{ .Revision }}
 
-  # Build dev job
-  # Build the Docker container ready for development
-  build-dev:
-
-    machine:
-      docker_layer_caching: true
-
-    working_directory: ~/fun
-
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - edx-v1-{{ .Revision }}
-            - edx-v1-
-
-      # Development container build, it uses the Dockerfile_dev file and will be
-      # tagged as edxapp:dev
+      # Save the built images to filesystem so that we can cache them and
+      # restore them in subsequent jobs
       - run:
-          name: Build container
+          name: Save docker images to filesystem
           command: |
-            docker build -t edxapp:${CIRCLE_TAG:-latest}-dev -f Dockerfile_dev .
+            docker save -o edxapp.tar edxapp:latest edxapp:dev
+
+      # Cache built images as they will be tested and pushed to DockerHub
+      # in subsequent jobs
+      - save_cache:
+          paths:
+            - ~/fun/edxapp.tar
+          key: edx-image-v1-{{ .Revision }}
 
   # Hub job
   # Load and tag production/development containers to push them to the Docker hub
   # public registry
   hub:
 
-    machine:
-      docker_layer_caching: true
+    # We use the machine executor, i.e. a VM, not a container
+    machine: true
+
+    working_directory: ~/fun
 
     steps:
+      # Tag production/development docker images to push them to the DockerHub
+      # public registry
 
-      # Check that the BRANCH name is included in the TAG name. This is important because
-      # we handle several important branches (master, funmooc, funwb, etc.) and we must make
-      # sure that tag names are explicitly linked to a branch in order to avoid conflicts.
+      # First, check that the BRANCH name is included in the TAG name. This is important
+      # because we handle several important branches (master, funmooc, funwb, etc.) and
+      # we must make sure that tag names are explicitly linked to a branch in order to
+      # avoid conflicts
       - run:
           name: Check that the BRANCH name is included in the TAG name
           command: |
@@ -92,12 +95,18 @@ jobs:
               circleci step halt
             fi
 
-      # Check that docker images have been loaded
+      - restore_cache:
+          keys:
+            - edx-image-v1-{{ .Revision }}
+
+      # Load the docker images from our cache to docker and check that they have
+      # been effectively loaded
       - run:
           name: Check docker image tags
           command: |
-            docker images edxapp:${CIRCLE_TAG}
-            docker images edxapp:${CIRCLE_TAG}-dev
+            docker load < edxapp.tar
+            docker images edxapp:latest
+            docker images edxapp:dev
 
       # Login to DockerHub with encrypted credentials stored as secret
       # environment variables (set in CircleCI project settings)
@@ -110,7 +119,7 @@ jobs:
       - run:
           name: Tag container
           command: |
-            docker tag edxapp:${CIRCLE_TAG} fundocker/edxapp:${CIRCLE_TAG}
+            docker tag edxapp:latest fundocker/edxapp:${CIRCLE_TAG}
             docker images fundocker/edxapp:${CIRCLE_TAG}
 
       # Publish production container to DockerHub
@@ -122,59 +131,11 @@ jobs:
       - run:
           name: Tag dev container
           command: |
-            docker tag edxapp::${CIRCLE_TAG}-dev fundocker/edxapp:${CIRCLE_TAG}-dev
+            docker tag edxapp:dev fundocker/edxapp:${CIRCLE_TAG}-dev
             docker images fundocker/edxapp:${CIRCLE_TAG}-dev
       - run:
           name: Publish container
           command: docker push fundocker/edxapp:${CIRCLE_TAG}-dev
-
-  # Test job
-  # Run the Open edX test suite on build containers.
-  #
-  # FIXME: this job randomly fails for obscure reasons; we need to invest
-  # more time on this issue.
-  test:
-
-    # We use docker layers caching as we might build containers in this job
-    machine:
-      docker_layer_caching: true
-
-    working_directory: ~/fun
-
-    # Allow the execution of parallel sub-jobs (up to 4 for free plans on CircleCI)
-    parallelism: 4
-
-    steps:
-      - checkout
-
-      # ...and Open edX sources with the test suite to run
-      - restore_cache:
-          keys:
-            - edx-v1-{{ .Revision }}
-            - edx-v1-
-
-      # Run the test suite via the Open edX test script: scripts/all-tests.sh
-      # This script requires CI environment variable to run; those are passed to
-      # the container via the `-e` docker run option:
-      #
-      # - CIRCLECI: used by the CI script to select the CI strategy (depending
-      #   on the CI platform)
-      # - CIRCLE_NODE_INDEX/CIRCLE_NODE_TOTAL: used for the parallel execution
-      #   of the test suite
-      # - EDXAPP_TEST_MONGO_HOST: the mongo db host used in tests
-      #
-      # We also need to mount the git repository that is used to integrate
-      # metadata to coverage report (e.g. the current commit hash).
-      - run:
-          name: Run tests
-          command: |
-            docker-compose run --rm \
-              -e CIRCLECI \
-              -e CIRCLE_NODE_INDEX \
-              -e CIRCLE_NODE_TOTAL \
-              -e EDXAPP_TEST_MONGO_HOST='mongodb' \
-              -v "$HOME/fun/src/edx-platform/.git:/app/edx-platform/.git" \
-              lms-dev scripts/all-tests.sh
 
 # CI workflows
 workflows:
@@ -193,16 +154,7 @@ workflows:
             tags:
               only: /.*/
 
-      # Build the development container only if the production container build
-      # succeeds
-      - build-dev:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
-
-      # Once the build-dev job has succeeded, we fork the workflow to run both
+      # Once the build job has succeeded, we fork the workflow to run both
       # the hub and the test jobs "in parallel".
       #
       # We are pushing to Docker only images that are the result of a tag respecting the pattern:
@@ -217,17 +169,9 @@ workflows:
       #    * eucalyptus-funwb-2.3.19
       - hub:
           requires:
-            - build-dev
+            - build
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /^[a-z0-9.]*-[a-z]*-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
-
-      # FIXME: for now this job can fail
-      - test:
-          requires:
-            - build-dev
-          filters:
-            tags:
-              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,13 +38,13 @@ jobs:
       - run:
           name: Build container
           command: |
-            docker build -t edxapp:latest .
+            docker build -t edxapp:${CIRCLE_TAG:-latest} .
 
       # Cache Open edX repository (cloned in ~/fun/src) as the checkout is
       # rather time consuming for this project
       - save_cache:
           paths:
-            - ~/fun/src
+            - ~/fun/src/edx-platform/.git
           key: edx-v1-{{ .Revision }}
 
   # Build dev job
@@ -69,7 +69,7 @@ jobs:
       - run:
           name: Build container
           command: |
-            docker build -t edxapp:dev -f Dockerfile_dev .
+            docker build -t edxapp:${CIRCLE_TAG:-latest}-dev -f Dockerfile_dev .
 
   # Hub job
   # Load and tag production/development containers to push them to the Docker hub
@@ -81,11 +81,23 @@ jobs:
 
     steps:
 
+      # Check that the BRANCH name is included in the TAG name. This is important because
+      # we handle several important branches (master, funmooc, funwb, etc.) and we must make
+      # sure that tag names are explicitly linked to a branch in order to avoid conflicts.
+      - run:
+          name: Check that the BRANCH name is included in the TAG name
+          command: |
+            if ! echo ${CIRCLE_TAG} | grep "${CIRCLE_BRANCH}" &> /dev/null; then
+              # Stop the step without failing
+              circleci step halt
+            fi
+
       # Check that docker images have been loaded
       - run:
           name: Check docker image tags
           command: |
-            docker images edxapp
+            docker images edxapp:${CIRCLE_TAG}
+            docker images edxapp:${CIRCLE_TAG}-dev
 
       # Login to DockerHub with encrypted credentials stored as secret
       # environment variables (set in CircleCI project settings)
@@ -98,23 +110,23 @@ jobs:
       - run:
           name: Tag container
           command: |
-            docker tag edxapp fundocker/edxapp:ginkgo.1
-            docker images fundocker/edxapp
+            docker tag edxapp:${CIRCLE_TAG} fundocker/edxapp:${CIRCLE_TAG}
+            docker images fundocker/edxapp:${CIRCLE_TAG}
 
       # Publish production container to DockerHub
       - run:
           name: Publish container
-          command: docker push fundocker/edxapp:ginkgo.1
+          command: docker push fundocker/edxapp:${CIRCLE_TAG}
 
       # Tag the development container, check tags, and publish it!
       - run:
           name: Tag dev container
           command: |
-            docker tag edxapp:dev fundocker/edxapp:ginkgo.1-dev
-            docker images fundocker/edxapp
+            docker tag edxapp::${CIRCLE_TAG}-dev fundocker/edxapp:${CIRCLE_TAG}-dev
+            docker images fundocker/edxapp:${CIRCLE_TAG}-dev
       - run:
           name: Publish container
-          command: docker push fundocker/edxapp:ginkgo.1-dev
+          command: docker push fundocker/edxapp:${CIRCLE_TAG}-dev
 
   # Test job
   # Run the Open edX test suite on build containers.
@@ -192,12 +204,25 @@ workflows:
 
       # Once the build-dev job has succeeded, we fork the workflow to run both
       # the hub and the test jobs "in parallel".
+      #
+      # We are pushing to Docker only images that are the result of a tag respecting the pattern:
+      #    {branch name}-{simplified semver}
+      #
+      # Where branch name is composed of two words representing:
+      #    1) The full edx-platform version name,
+      #    2) The name of a specific branch on edx-platform issued from the above official version.
+      #
+      # Some valid examples:
+      #    * dogwood.3-funmooc-1.0.0
+      #    * eucalyptus-funwb-2.3.19
       - hub:
           requires:
             - build-dev
           filters:
             branches:
-              only: master
+              ignore: /.*/
+            tags:
+              only: /^[a-z0-9.]*-[a-z]*-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
 
       # FIXME: for now this job can fail
       - test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,18 @@ RUN apt-get update && \
     apt-get install -y build-essential curl g++ gcc gettext gfortran git git-core \
     graphviz graphviz-dev language-pack-en libffi-dev libfreetype6-dev libgeos-dev \
     libjpeg8-dev liblapack-dev libmysqlclient-dev libpng12-dev libxml2-dev \
-    libxmlsec1-dev libxslt1-dev nodejs nodejs-legacy npm ntp pkg-config python-apt python-dev \
-    python-pip software-properties-common swig && \
+    libxmlsec1-dev libxslt1-dev nodejs npm ntp pkg-config python-apt python-dev \
+    python-pip software-properties-common swig \
+    python-software-properties \
+    libatlas-dev libblas-dev locales python-scipy python-numpy \
+    libjpeg-dev zlib1g-dev libxslt-dev \
+    yui-compressor libgraphviz-dev graphviz-dev \
+    libreadline6 libreadline6-dev nodejs coffeescript mysql-client \
+    libgeos-ruby1.8 lynx-cur libxmlsec1-dev \
+    wget libssl-dev && \
     rm -rf /var/lib/apt/lists/*
 
+RUN ln -s /usr/bin/nodejs /usr/bin/node
 WORKDIR /edx/app/edxapp/edx-platform
 
 # Install Python requirements
@@ -26,6 +34,10 @@ RUN pip install --src ../src -r requirements/edx/pre.txt && \
 # ... adding only the package.json file first to benefit from caching
 ADD ./src/edx-platform/package.json /edx/app/edxapp/edx-platform/package.json
 RUN npm install
+
+# Force the reinstallation of edx-ui-toolkit's dependencies inside its node_modules
+# because someone is poking files from there when updating assets.
+RUN cd /edx/app/edxapp/edx-platform/node_modules/edx-ui-toolkit && npm install
 
 # Now add the complete project sources
 ADD ./src/edx-platform /edx/app/edxapp/edx-platform

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -7,8 +7,7 @@ RUN apt-get update && \
     apt-get install -y libsqlite3-dev mongodb && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --src ../src -r requirements/edx/testing.txt && \
-    pip install --src ../src -r requirements/edx/development.txt
+RUN pip install --src ../src -r requirements/edx/development.txt
 
 # Copy default configurations for development
 COPY ./config /config/

--- a/bin/clone_repositories
+++ b/bin/clone_repositories
@@ -10,6 +10,6 @@ git remote add edx https://github.com/edx/edx-platform.git
 git remote add openfun https://github.com/openfun/edx-platform.git
 # Better do the checkout separately from the clone so that if the repository
 # already exists, the checkout is still done to the branch we want.
-git fetch edx open-release/ginkgo.1
-git checkout -f open-release/ginkgo.1
+git fetch openfun fun/whitebrand
+git checkout -f fun/whitebrand
 

--- a/bin/clone_repositories
+++ b/bin/clone_repositories
@@ -2,10 +2,14 @@
 
 echo -e "\033[1;33mGetting edx-platform\033[0m"
 # Clone it from here to get a better message in command line
-git clone https://github.com/edx/edx-platform.git src/edx-platform
+git clone --no-checkout https://github.com/edx/edx-platform.git src/edx-platform
 cd src/edx-platform
-# Clean node installations in case the repo pre-existed
-git clean -fdx
+# Create both remotes for CI as other branches may have created/used
+# them and it was saved in cache.
+git remote add edx https://github.com/edx/edx-platform.git
+git remote add openfun https://github.com/openfun/edx-platform.git
 # Better do the checkout separately from the clone so that if the repository
 # already exists, the checkout is still done to the branch we want.
-git checkout open-release/ginkgo.1
+git fetch edx open-release/ginkgo.1
+git checkout -f open-release/ginkgo.1
+


### PR DESCRIPTION
We are pushing to Docker only images that are the result of a tag respecting the pattern:
    **{branch_name}-{semver}**

Where branch name is composed of two words representing:
    1) edx-platform full version name,
    2) FUN's specific fork project.

Valid examples:
    * dogwood.3-funmooc-1.0.0
    * eucalyptus-funwb-2.3.19-rc3
