### PR TITLE
🚚(config) rename custom configuration files

### DIFF
--- a/config/lms/utils.py
+++ b/config/lms/utils.py
@@ -8,29 +8,33 @@ from django.core.exceptions import ImproperlyConfigured
 
 class Configuration(dict):
     """
-    Try getting a setting from the settings.yaml or credentials.vault.yaml files placed
-    in the directory passed when initializing the configuration instance.
+    Try getting a setting from the settings.yml or secrets.yml files placed in
+    the directory passed when initializing the configuration instance.
     """
+
     def __init__(self, dir, *args, **kwargs):
         """
-        Initialize with the path to the directory in which the configuration is to be found.
+        Initialize with the path to the directory in which the configuration is
+        to be found.
         """
         super(Configuration, self).__init__(*args, **kwargs)
 
-        # Load the content of a `settings.yaml` file placed in the current directory if any
-        # This file is where customisable settings are stored for a given environment
+        # Load the content of a `settings.yml` file placed in the current
+        # directory if any. This file is where customizable settings are stored
+        # for a given environment.
         try:
-            with open(os.path.join(dir, 'settings.yaml')) as f:
+            with open(os.path.join(dir, "settings.yml")) as f:
                 settings = yaml.load(f.read())
         except IOError:
             settings = {}
         else:
             settings = settings or {}
 
-        # Load the content of a `credentials.vault.yaml` file placed in the current directory if
-        # any. This file is where sensitive settings are stored for a given environment
+        # Load the content of a `secrets.yml` file placed in the current
+        # directory if any. This file is where sensitive credentials are stored
+        # for a given environment.
         try:
-            with open(os.path.join(dir, 'credentials.vault.yaml')) as f:
+            with open(os.path.join(dir, "credentials.vault.yml")) as f:
                 credentials = yaml.load(f.read())
         except IOError:
             credentials = {}
@@ -43,12 +47,14 @@ class Configuration(dict):
     def __call__(self, var_name, *args, **kwargs):
         """
         The config returns in order of priority:
-            - the value set in the credentials.vault.yaml file,
-            - the value set in the settings.yaml file,
+
+            - the value set in the secrets.yml file,
+            - the value set in the settings.yml file,
             - the value passed as default.
-        Raise an "ImproperlyConfigured" error if the name is not found, except if the `default`
-        key is given in kwargs (using kwargs allows to pass a default to None, which is different
-        from not passing any default):
+
+        Raise an "ImproperlyConfigured" error if the name is not found, except
+        if the `default` key is given in kwargs (using kwargs allows to pass a
+        default to None, which is different from not passing any default):
 
             $ config = Configuration('path/to/config/directory')
             $ config('foo')  # raise ImproperlyConfigured error if `foo` is not defined
@@ -58,8 +64,9 @@ class Configuration(dict):
         try:
             return self.settings[var_name]
         except KeyError:
-            if 'default' in kwargs:
-                return kwargs['default']
+            if "default" in kwargs:
+                return kwargs["default"]
             raise ImproperlyConfigured(
-                'Please set the "{:s}" variable in a `settings.yaml` '
-                'or `credentials.vault.yaml` file.'.format(var_name))
+                'Please set the "{:s}" variable in a `settings.yml` '
+                "or  secrets.yml` file.".format(var_name)
+            )


### PR DESCRIPTION
## Purpose

We need to make settings override via YAML files more generic.

## Proposal

Expected configurations files names to override settings are now:

* `settings.yml` (prev. `settings.yaml`) as the `.yml` extension is more
   oftlenly used than `.yaml`.
* `secrets.yml` (prev. `credentials.vault.yml`) as we try to make
  the generation of this file independent from ansible (vault).

I've also slightly fixed docstrings/comments formatting (black style) :wink: