### PR TITLE
Add image utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y build-essential curl g++ gcc gettext gfortran git git-core \
     graphviz graphviz-dev language-pack-en libffi-dev libfreetype6-dev libgeos-dev \
-    libjpeg8-dev liblapack-dev libmysqlclient-dev libpng12-dev libxml2-dev \
+    libjpeg8-dev liblapack-dev libmysqlclient-dev libpng12-dev libreadline6 libxml2-dev \
     libxmlsec1-dev libxslt1-dev nodejs nodejs-legacy npm ntp pkg-config python-apt python-dev \
     python-pip software-properties-common swig tzdata && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -4,7 +4,7 @@ FROM edxapp:latest
 # Removing the package lists after installation is a good practice
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y libsqlite3-dev mongodb && \
+    apt-get install -y dnsutils iputils-ping libsqlite3-dev mongodb && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --src ../src -r requirements/edx/testing.txt && \


### PR DESCRIPTION
## Purpose

We need base commands or utilities to debug our running Docker containers (usable shell, and network tools).

## Proposal

* Add `libreadline` to the base image
* Add `ping` and `nslookup` / `dig` the the development image 