### PR TITLE
Make Celery workers great again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN echo $TZ > /etc/timezone && \
 WORKDIR /edx/app/edxapp/edx-platform
 
 # Install Python requirements
+# -- edx requirements
 # ... adding only targeted requirements files first to benefit from caching
 COPY ./src/edx-platform/requirements/edx /edx/app/edxapp/edx-platform/requirements/edx
 RUN pip install --src ../src -r requirements/edx/pre.txt && \
@@ -29,6 +30,9 @@ RUN pip install --src ../src -r requirements/edx/pre.txt && \
     pip install --src ../src -r requirements/edx/base.txt && \
     pip install --src ../src -r requirements/edx/paver.txt && \
     pip install --src ../src -r requirements/edx/post.txt
+# -- fun requirements
+COPY ./requirements/features.txt /edx/app/edxapp/edx-platform/requirements/edx/features.txt
+RUN pip install --src ../src -r requirements/edx/features.txt
 
 # Install Javascript requirements
 # ... adding only the package.json file first to benefit from caching

--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -60,6 +60,12 @@ CELERY_QUEUES = config("CELERY_QUEUES", default={
 
 CELERY_ROUTES = 'cms.celery.Router'
 
+# Force accepted content to "json" only. If we also accept pickle-serialized
+# messages, the worker will crash when it's running with a privileged user (even
+# if it's not the root user but a user belonging to the root group, which is our
+# case with OpenShift).
+CELERY_ACCEPT_CONTENT = ['json']
+
 ############# NON-SECURE ENV CONFIG ##############################
 # Things like server locations, ports, etc.
 

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -73,6 +73,12 @@ CELERY_QUEUES = config("CELERY_QUEUES", default={
 
 CELERY_ROUTES = 'lms.celery.Router'
 
+# Force accepted content to "json" only. If we also accept pickle-serialized
+# messages, the worker will crash when it's running with a privileged user (even
+# if it's not the root user but a user belonging to the root group, which is our
+# case with OpenShift).
+CELERY_ACCEPT_CONTENT = ['json']
+
 # If we're a worker on the high_mem queue, set ourselves to die after processing
 # one request to avoid having memory leaks take down the worker server. This env
 # var is set in /etc/init/edx-workers.conf -- this should probably be replaced
@@ -348,7 +354,7 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'level': 'INFO'
         },
-    },        
+    },
     'formatters': {
         'raw': {'format': '%(message)s'},
         'syslog_format': {'format': syslog_format},
@@ -362,8 +368,8 @@ LOGGING = {
             'handlers': ['console', 'local']
         },
         'tracking': {
-            'level': 'DEBUG', 
-            'propagate': False, 
+            'level': 'DEBUG',
+            'propagate': False,
             'handlers': ['tracking']
         }
     }

--- a/requirements/features.txt
+++ b/requirements/features.txt
@@ -1,0 +1,2 @@
+# Feature-related requirements
+redis==2.10.6  # celery task broker


### PR DESCRIPTION
## Purpose

After having tested recent work related to celery configuration, we needed to make minor adjustments to make celery workers functional.

## Proposal

- [x] Add `redis` python dependency
- [x] Configure Celery to only accept json-serialized messages.