### PR TITLE
Make theme configurable in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,12 +47,8 @@ COPY ./config /config
 RUN ln -sf /config/lms /edx/app/edxapp/edx-platform/lms/envs/fun && \
     ln -sf /config/cms /edx/app/edxapp/edx-platform/cms/envs/fun
 
-# Update assets
-# - Add minimal settings just to enable updating assets during container build
-COPY ./config/docker_build.py /edx/app/edxapp/edx-platform/lms/envs/
-COPY ./config/docker_build.py /edx/app/edxapp/edx-platform/cms/envs/
-# - Update assets skipping collectstatic (it should be done during deployment)
-RUN paver update_assets --settings=docker_build --skip-collect
+# Update assets skipping collectstatic (it should be done during deployment)
+RUN paver update_assets --settings=fun.docker_build_production --skip-collect
 
 # Use Gunicorn in production as web server
 CMD DJANGO_SETTINGS_MODULE=${SERVICE_VARIANT}.envs.fun.docker_run \

--- a/config/cms/docker_build_development.py
+++ b/config/cms/docker_build_development.py
@@ -1,0 +1,4 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the development image of the edxapp CMS
+
+from docker_build_production import *

--- a/config/cms/docker_build_production.py
+++ b/config/cms/docker_build_production.py
@@ -1,0 +1,27 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the production image of the edxapp CMS
+
+from path import Path as path
+
+from lms.envs.fun.utils import Configuration
+
+from ..common import *
+
+
+# Load custom configuration parameters
+config = Configuration()
+
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile
+
+DATABASES = {"default": {}}
+
+XQUEUE_INTERFACE = {"url": None, "django_auth": None}
+
+# We need to override STATIC_ROOT because for CMS, edX appends the value of
+# "EDX_PLATFORM_REVISION" to it by default and we don't want to use this.
+# We should use Django's ManifestStaticFilesStorage for this purpose.
+STATIC_ROOT = path('/edx/app/edxapp/staticfiles')
+
+# Allow setting a custom theme
+DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)

--- a/config/lms/docker_build_development.py
+++ b/config/lms/docker_build_development.py
@@ -1,0 +1,4 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the development image of the edxapp LMS
+
+from docker_build_production import *

--- a/config/lms/docker_build_production.py
+++ b/config/lms/docker_build_production.py
@@ -1,6 +1,14 @@
+# This is a minimal settings file allowing us to run "update_assets"
+# in the Dockerfile for the production image of the edxapp LMS
+
 from path import Path as path
 
-from .common import *
+from ..common import *
+from .utils import Configuration
+
+
+# Load custom configuration parameters
+config = Configuration()
 
 # This is a minimal settings file allowing us to run "update_assets"
 # in the Dockerfile
@@ -13,3 +21,6 @@ XQUEUE_INTERFACE = {"url": None, "django_auth": None}
 # "EDX_PLATFORM_REVISION" to it by default and we don't want to use this.
 # We should use Django's ManifestStaticFilesStorage for this purpose.
 STATIC_ROOT = path('/edx/app/edxapp/staticfiles')
+
+# Allow setting a custom theme
+DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)

--- a/config/lms/utils.py
+++ b/config/lms/utils.py
@@ -28,22 +28,18 @@ class Configuration(dict):
             # for a given environment.
             try:
                 with open(os.path.join(dir, "settings.yml")) as f:
-                    settings = yaml.load(f.read())
+                    settings = yaml.load(f.read()) or {}
             except IOError:
                 settings = {}
-            else:
-                settings = settings or {}
 
             # Load the content of a `secrets.yml` file placed in the current
             # directory if any. This file is where sensitive credentials are stored
             # for a given environment.
             try:
                 with open(os.path.join(dir, "secrets.yml")) as f:
-                    credentials = yaml.load(f.read())
+                    credentials = yaml.load(f.read()) or {}
             except IOError:
                 credentials = {}
-            else:
-                credentials = credentials or {}
 
             settings.update(credentials)
             self.settings = settings


### PR DESCRIPTION
## Purpose

We want to be able to set a custom theme when building the Docker image in an OpenShift buildconfig. Since the config volumes are not mounted in buildconfigs, we propose to allow setting it via an environment variable.

## Proposal

- [x] allow setting config parameters via environment variables
- [x] make the "DEFAULT_SITE_THEME" setting configurable in build settings.

Note: I also moved the docker_build.py file to /lms and /cms so that it works the same as in Hawthorn and we can do the same thing in Arnold to deploy...