### PR TITLE
[hawthorn.1] 🐛(statics) remove webpack stats from STATIC_ROOT

### DIFF
--- a/config/cms/docker_build_production.py
+++ b/config/cms/docker_build_production.py
@@ -21,6 +21,12 @@ XQUEUE_INTERFACE = {"url": None, "django_auth": None}
 STATIC_URL = "/static/studio/"
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
 
+# Generate webpack stats file in the project's root and not in STATIC_ROOT or
+# else, we'll be forced to copy it manually as it won't be collected.
+WEBPACK_LOADER["DEFAULT"][
+    "STATS_FILE"
+] = "/edx/app/edxapp/edx-platform/webpack-stats-cms.json"
+
 # Allow setting a custom theme
 DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)
 

--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -101,7 +101,11 @@ GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
 STATIC_URL = "/static/studio/"
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
 
-WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
+# Generate webpack stats file in the project's root and not in STATIC_ROOT or
+# else, we'll be forced to copy it manually as it won't be collected.
+WEBPACK_LOADER["DEFAULT"][
+    "STATS_FILE"
+] = "/edx/app/edxapp/edx-platform/webpack-stats-cms.json"
 
 EMAIL_BACKEND = config("EMAIL_BACKEND", default=EMAIL_BACKEND)
 EMAIL_FILE_PATH = config("EMAIL_FILE_PATH", default=None)

--- a/config/lms/docker_build_production.py
+++ b/config/lms/docker_build_production.py
@@ -16,6 +16,12 @@ XQUEUE_INTERFACE = {"url": None, "django_auth": None}
 
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles")
 
+# Generate webpack stats file in the project's root and not in STATIC_ROOT or
+# else, we'll be forced to copy it manually as it won't be collected.
+WEBPACK_LOADER["DEFAULT"][
+    "STATS_FILE"
+] = "/edx/app/edxapp/edx-platform/webpack-stats-lms.json"
+
 # Allow setting a custom theme
 DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)
 

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -96,7 +96,11 @@ CELERYBEAT_SCHEDULE = {}  # For scheduling tasks, entries can be added to this d
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles")
 STATIC_URL = "/static/"
 
-WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
+# Generate webpack stats file in the project's root and not in STATIC_ROOT or
+# else, we'll be forced to copy it manually as it won't be collected.
+WEBPACK_LOADER["DEFAULT"][
+    "STATS_FILE"
+] = "/edx/app/edxapp/edx-platform/webpack-stats-lms.json"
 
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"


### PR DESCRIPTION
# Purpose

**Backport of #38 for `hawthorn.1`**

There is no obvious reason to store `webpack-stats.json` files in the `STATIC_ROOT` tree. It causes more problem than it solves as we need to manually copy it during deployment since it is not collected via collectstatics.

## Proposal

- [x] Update target file path in production settings for both LMS and CMS