### PR TITLE
⏪(statics) revert webpack loader settings

### DIFF
--- a/config/cms/docker_build_production.py
+++ b/config/cms/docker_build_production.py
@@ -21,12 +21,6 @@ XQUEUE_INTERFACE = {"url": None, "django_auth": None}
 STATIC_URL = "/static/studio/"
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
 
-# Generate webpack stats file in the project's root and not in STATIC_ROOT or
-# else, we'll be forced to copy it manually as it won't be collected.
-WEBPACK_LOADER["DEFAULT"][
-    "STATS_FILE"
-] = "/edx/app/edxapp/edx-platform/webpack-stats-cms.json"
-
 # Allow setting a custom theme
 DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)
 

--- a/config/cms/docker_run_production.py
+++ b/config/cms/docker_run_production.py
@@ -101,11 +101,7 @@ GITHUB_REPO_ROOT = config("GITHUB_REPO_ROOT", default=GITHUB_REPO_ROOT)
 STATIC_URL = "/static/studio/"
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles/studio")
 
-# Generate webpack stats file in the project's root and not in STATIC_ROOT or
-# else, we'll be forced to copy it manually as it won't be collected.
-WEBPACK_LOADER["DEFAULT"][
-    "STATS_FILE"
-] = "/edx/app/edxapp/edx-platform/webpack-stats-cms.json"
+WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
 
 EMAIL_BACKEND = config("EMAIL_BACKEND", default=EMAIL_BACKEND)
 EMAIL_FILE_PATH = config("EMAIL_FILE_PATH", default=None)

--- a/config/lms/docker_build_production.py
+++ b/config/lms/docker_build_production.py
@@ -16,12 +16,6 @@ XQUEUE_INTERFACE = {"url": None, "django_auth": None}
 
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles")
 
-# Generate webpack stats file in the project's root and not in STATIC_ROOT or
-# else, we'll be forced to copy it manually as it won't be collected.
-WEBPACK_LOADER["DEFAULT"][
-    "STATS_FILE"
-] = "/edx/app/edxapp/edx-platform/webpack-stats-lms.json"
-
 # Allow setting a custom theme
 DEFAULT_SITE_THEME = config("DEFAULT_SITE_THEME", default=None)
 

--- a/config/lms/docker_run_production.py
+++ b/config/lms/docker_run_production.py
@@ -96,11 +96,7 @@ CELERYBEAT_SCHEDULE = {}  # For scheduling tasks, entries can be added to this d
 STATIC_ROOT = path("/edx/app/edxapp/staticfiles")
 STATIC_URL = "/static/"
 
-# Generate webpack stats file in the project's root and not in STATIC_ROOT or
-# else, we'll be forced to copy it manually as it won't be collected.
-WEBPACK_LOADER["DEFAULT"][
-    "STATS_FILE"
-] = "/edx/app/edxapp/edx-platform/webpack-stats-lms.json"
+WEBPACK_LOADER["DEFAULT"]["STATS_FILE"] = STATIC_ROOT / "webpack-stats.json"
 
 MEDIA_ROOT = path("/edx/var/edxapp/media/")
 MEDIA_URL = "/media/"


### PR DESCRIPTION
## Purpose

In fact, changing django settings is not sufficient to change the `webpack-stats.json` path. We also need to update front-end settings that enforce the usage of the  èSTATIC_ROOT` directory as the target path to generate it (see https://github.com/edx/edx-platform/blob/master/webpack.common.config.js#L94).

## Proposal

For now, we will wait for edx to fix it, and we will declare a new issue to let them know what problem we encountered. This PR reverts previous changes to the settings.
