### PR TITLE
🐛(settings) fix EMAIL_BACKEND default

### DIFF
--- a/config/cms/docker_run_feature.py
+++ b/config/cms/docker_run_feature.py
@@ -8,5 +8,5 @@ from lms.envs.fun.utils import Configuration
 config = Configuration(os.path.dirname(__file__))
 
 EMAIL_BACKEND = config(
-    "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )

--- a/config/cms/docker_run_preprod.py
+++ b/config/cms/docker_run_preprod.py
@@ -8,5 +8,5 @@ from lms.envs.fun.utils import Configuration
 config = Configuration(os.path.dirname(__file__))
 
 EMAIL_BACKEND = config(
-    "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )

--- a/config/cms/docker_run_staging.py
+++ b/config/cms/docker_run_staging.py
@@ -8,5 +8,5 @@ from lms.envs.fun.utils import Configuration
 config = Configuration(os.path.dirname(__file__))
 
 EMAIL_BACKEND = config(
-    "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )

--- a/config/lms/docker_run_feature.py
+++ b/config/lms/docker_run_feature.py
@@ -8,5 +8,5 @@ from .utils import Configuration
 config = Configuration(os.path.dirname(__file__))
 
 EMAIL_BACKEND = config(
-    "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )

--- a/config/lms/docker_run_preprod.py
+++ b/config/lms/docker_run_preprod.py
@@ -8,5 +8,5 @@ from .utils import Configuration
 config = Configuration(os.path.dirname(__file__))
 
 EMAIL_BACKEND = config(
-    "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )

--- a/config/lms/docker_run_staging.py
+++ b/config/lms/docker_run_staging.py
@@ -8,5 +8,5 @@ from .utils import Configuration
 config = Configuration(os.path.dirname(__file__))
 
 EMAIL_BACKEND = config(
-    "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+    "EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend"
 )


### PR DESCRIPTION
## Purpose

`EMAIL_BACKEND` settings in some environments is broken since 766fcd8.

**backport of #55 to `master`**

## Proposal

- [x] add a "default" keyword to `EMAIL_BACKEND` configuration for both cms & lms settings (preprod, staging and feature environments)
