### PR TITLE
🐛(dogwood/3/bare|fun) pin `splinter` version to 0.13.0

### DIFF
--- a/releases/dogwood/3/bare/CHANGELOG.md
+++ b/releases/dogwood/3/bare/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin splinter to 0.13.0 to avoid breaking change in 0.14.0
+
 ## [dogwood.3-1.3.0] - 2020-05-14
 
 ### Added

--- a/releases/dogwood/3/bare/Dockerfile
+++ b/releases/dogwood/3/bare/Dockerfile
@@ -153,7 +153,8 @@ RUN pip install -r requirements/edx/pre.txt
 RUN pip install \
       astroid==1.6.0 \
       django==1.8.12 \
-      pip==9.0.3
+      pip==9.0.3 \
+      splinter==0.13.0
 RUN pip install --src /usr/local/src -r requirements/edx/github.txt
 RUN pip install -r requirements/edx/base.txt
 RUN pip install -r requirements/edx/paver.txt

--- a/releases/dogwood/3/fun/CHANGELOG.md
+++ b/releases/dogwood/3/fun/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin splinter to 0.13.0 to avoid breaking change in 0.14.0
+
 ## [dogwood.3-fun-1.13.1] - 2020-07-20
 
 ### Changed

--- a/releases/dogwood/3/fun/Dockerfile
+++ b/releases/dogwood/3/fun/Dockerfile
@@ -157,7 +157,8 @@ RUN pip install -r requirements/edx/pre.txt
 RUN pip install \
       astroid==1.6.0 \
       django==1.8.12 \
-      pip==9.0.3
+      pip==9.0.3 \
+      splinter==0.13.0
 RUN pip install --src /usr/local/src -r requirements/edx/github.txt
 RUN pip install -r requirements/edx/base.txt
 RUN pip install -r requirements/edx/paver.txt


### PR DESCRIPTION
## Purpose

The 0.14.0 version of spliter introduced a change that breaks our `dogwood` builds because it is a subdependency and not pinned.

## Proposal

Pin splinter to version 0.13.0 for `dogwood.3-bare` and `dogwood.3-fun`