### PR TITLE
🐛(eucalyptus/3/wb) use PyOpenSSL for SSL certificate checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,10 +151,10 @@ jobs:
   #
   # Note that the job name should match the EDX_RELEASE value
 
-  # Run jobs for the dogwood.3-fun release
-  dogwood.3-fun:
+  # No changes detected for dogwood.3-fun
+  # Run jobs for the eucalyptus.3-wb release
+  eucalyptus.3-wb:
     <<: [*defaults, *build_steps]
-  # No changes detected for eucalyptus.3-wb
   # No changes detected for hawthorn.1-oee
   # No changes detected for ironwood.2-oee
 
@@ -238,14 +238,14 @@ workflows:
 
       # Build jobs
 
-      # Run jobs for the dogwood.3-fun release
-      - dogwood.3-fun:
+      # No changes detected so no job to run for dogwood.3-fun
+      # Run jobs for the eucalyptus.3-wb release
+      - eucalyptus.3-wb:
           requires:
             - check-configuration
           filters:
             tags:
               ignore: /.*/
-      # No changes detected so no job to run for eucalyptus.3-wb
       # No changes detected so no job to run for hawthorn.1-oee
       # No changes detected so no job to run for ironwood.2-oee
 

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use pyOpenSSL instead of local openssl library for SSL certificate checking
+
 ## [eucalyptus.3-wb-1.13.0] - 2023-05-17
 
 ### Added

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ### Fixed
 
 - Fix `astrolib` and `singlepatch` install by installing pip first
+- Remove dependency to missing Python package `moto` only used in tests
 - Use pyOpenSSL instead of local openssl library for SSL certificate checking
 
 ## [eucalyptus.3-wb-1.13.0] - 2023-05-17

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [eucalyptus.3-wb-1.13.1] - 2025-07-09
+
 ### Fixed
 
 - Fix `astrolib` and `singlepatch` install by installing pip first
@@ -310,7 +312,8 @@ release.
 - Set replicaSet and read_preference in mongodb connection
 - Add missing support for redis sentinel
 
-[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.13.0...HEAD
+[unreleased]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.13.1...HEAD
+[eucalyptus.3-wb-1.13.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.13.0...eucalyptus.3-wb-1.13.1
 [eucalyptus.3-wb-1.13.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.12.1...eucalyptus.3-wb-1.13.0
 [eucalyptus.3-wb-1.12.1]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.12.0...eucalyptus.3-wb-1.12.1
 [eucalyptus.3-wb-1.12.0]: https://github.com/openfun/openedx-docker/compare/eucalyptus.3-wb-1.11.0...eucalyptus.3-wb-1.12.0

--- a/releases/eucalyptus/3/wb/CHANGELOG.md
+++ b/releases/eucalyptus/3/wb/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 ### Fixed
 
+- Fix `astrolib` and `singlepatch` install by installing pip first
 - Use pyOpenSSL instead of local openssl library for SSL certificate checking
 
 ## [eucalyptus.3-wb-1.13.0] - 2023-05-17

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -143,6 +143,7 @@ RUN pip install \
     astroid==1.6.0 \
     django==1.8.15 \
     pip==9.0.3
+    urllib3==1
 RUN pip install --upgrade setuptools
 RUN pip install --src /usr/local/src -r requirements/edx/github.txt
 RUN pip install -r requirements/edx/base.txt

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -136,13 +136,13 @@ RUN patch -p1 < /tmp/edx-platform_eucalyptus.3-remove_faulthandler.patch
 # dependencies to prevent secondary dependencies installation to fail while
 # trying to install a python 2.7 incompatible release
 RUN pip install -r requirements/edx/pre.txt
+RUN pip install pip==9.0.3 
 RUN pip install \
     django-braces==1.14.0 \
     wrapt==1.12.1 \
     lazy-object-proxy==1.5.2 \
     astroid==1.6.0 \
     django==1.8.15 \
-    pip==9.0.3
     urllib3==1
 RUN pip install --upgrade setuptools
 RUN pip install --src /usr/local/src -r requirements/edx/github.txt

--- a/releases/eucalyptus/3/wb/Dockerfile
+++ b/releases/eucalyptus/3/wb/Dockerfile
@@ -129,6 +129,8 @@ COPY patches/* /tmp/
 # Patches pre-install
 # Remove faulthandler dependency that is no more available and is useful only for running tests
 RUN patch -p1 < /tmp/edx-platform_eucalyptus.3-remove_faulthandler.patch
+# Patch to fix installation of Python modules
+RUN patch -p1 < /tmp/edx-platform_eucalyptus.3-fun_moto.patch
 
 # Install python dependencies
 #

--- a/releases/eucalyptus/3/wb/patches/edx-platform_eucalyptus.3-fun_moto.patch
+++ b/releases/eucalyptus/3/wb/patches/edx-platform_eucalyptus.3-fun_moto.patch
@@ -1,0 +1,13 @@
+diff --git i/requirements/edx/base.txt w/requirements/edx/base.txt
+index 9bc8908d72..1b984f9283 100644
+--- i/requirements/edx/base.txt
++++ w/requirements/edx/base.txt
+@@ -154,7 +154,7 @@ flaky==2.4.0
+ freezegun==0.1.11
+ mock-django==0.6.9
+ mock==1.0.1
+-moto==0.3.1
++#moto==0.3.1 version not available anymore but we don't need to run the tests anyway
+ nose==1.3.7
+ nose-exclude
+ nose-ignore-docstring

--- a/releases/eucalyptus/3/wb/requirements.txt
+++ b/releases/eucalyptus/3/wb/requirements.txt
@@ -23,3 +23,9 @@ django-redis-sessions==0.6.1
 raven==6.9.0
 redis==2.10.6
 gunicorn==19.9.0
+
+# Upgrade requests and urllib3 to prevent SSL certificate validation failure
+# (we should use pyOpenSSL instead of the local openssl library). For reference, see:
+# https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
+requests==2.27.1
+urllib3[secure]==1.26.20


### PR DESCRIPTION
## Purpose

Switching the `VIDEOFRONT_CDN_BASE_URL` from AWS CloudFront to Scaleway Edge introduces an issue where videos fail to load. The following error is raised when attempting to download the `metadata.json`:
```
Erreur : HTTPSConnectionPool(host='video.alt.openfun.fr', port=443): Max retries exceeded with url: /api/v1/videos/<video_id> (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7f76b4079910>: Failed to establish a new connection: [Errno -2] Name or service not known',))
```
This problem occurs because the `requests` library used in the current environment cannot properly requests the Scaleway Edge service, which uses Let's Encrypt certificates (probably because of [this](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/)). The error encountered is an SSL verification failure:
```
>>> import requests
>>> requests.get("https://xxx.svc.edge.scw.cloud/videos/<video_id>/metadata.json")
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 67, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 53, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 468, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/raven/breadcrumbs.py", line 326, in send
    resp = real_send(self, request, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 576, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 447, in send
    raise SSLError(e, request=request)
SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
```
while the same code works without issue when targeting CloudFront endpoints.

## Proposal

Greatly inspired by [this commit](https://github.com/openfun/openedx-docker/commit/5ede1355d407e05d4f23f9129c4d84fc988fb5a6), updating `requests` and `urllib3` with the latest versions compatible with Python 2.7

Additionally, the build process required some adjustments: 
- a fix for installing `astroid` and its dependencies, 
- a patch inspired by [this commit](https://github.com/openfun/openedx-docker/pull/340/commits/7878914ca3489421207a06213f657dfc3d6cc9bd) to remove `moto` installation.